### PR TITLE
Created an option to add a input field with an configurable name that…

### DIFF
--- a/bootstrap-confirmation.js
+++ b/bootstrap-confirmation.js
@@ -49,7 +49,8 @@
 						if($('.popover').has(e.target).length) return;
 
 						that.hide();
-						that.inState.click = false;
+						if(this.inState)
+							that.inState.click = false;
 
 						$('body').unbind(e);
 
@@ -79,6 +80,8 @@
 		btnCancelClass 	: 'btn btn-sm btn-default',
 		btnCancelLabel 	: 'Cancel',
 		btnCancelIcon 	: 'glyphicon glyphicon-remove',
+		messageName		: null,
+		messagePlaceholder: '',
 		href 			: '#',
 		target 			: '_self',
 		singleton 		: true,
@@ -113,7 +116,39 @@
 		var title      = this.getTitle();
 		var $btnOk     = $tip.find('[data-apply="confirmation"]');
 		var $btnCancel = $tip.find('[data-dismiss="confirmation"]');
+		var $content   = $tip.find('.popover-content');
 		var options    = this.options
+
+
+		if(this.getMessageName()) {
+
+
+
+			$tip.css('min-width', '300px');
+			$content.addClass('container-fluid');
+			var form = $('<form>').attr('action', this.getHref()).attr('target', this.getTarget());
+
+			var $btnOk = $('<button>')
+				.attr('type', 'submit')
+				.addClass(this.getBtnOkClass())
+				.prepend($('<i>').addClass(this.getBtnOkIcon()), this.getBtnOkLabel());
+
+			var input = $('<input>')
+				.attr('type', 'text')
+				.attr('name', this.getMessageName())
+				.attr('placeholder', this.getMessagePlaceholder())
+				.addClass('form-control input-sm');
+
+			form.append($('<div>', {'class' :'form-group'}).append(input));
+			form.append(
+				$('<div>', {'class' :'form-group'})
+					.append($btnOk)
+					.append('&nbsp;')
+					.append($btnCancel)
+			);
+
+			$content.html(form);
+		}
 
 		$btnOk.addClass(this.getBtnOkClass())
 			.html(this.getBtnOkLabel())
@@ -124,7 +159,8 @@
 				options.onConfirm(event, that.$element);
 
 				that.hide();
-				that.inState.click = false;
+				if(this.inState)
+					that.inState.click = false;
 			});
 
 		$btnCancel.addClass(this.getBtnCancelClass())
@@ -134,7 +170,8 @@
 				options.onCancel(event, that.$element);
 
 				that.hide();
-				that.inState.click = false;
+				if(this.inState)
+					that.inState.click = false;
 			});
 
 		$tip.find('.popover-title')[this.options.html ? 'html' : 'text'](title);
@@ -200,6 +237,20 @@
 		var o  = this.options;
 
 		return $e.attr('data-target') || (typeof o.target == 'function' ? o.target.call($e[0]) : o.target);
+	}
+
+	Confirmation.prototype.getMessageName = function () {
+		var $e = this.$element;
+		var o  = this.options;
+
+		return $e.attr('data-message-name') || (typeof o.target == 'function' ? o.target.call($e[0]) : o.messageName);
+	}
+
+	Confirmation.prototype.getMessagePlaceholder = function () {
+		var $e = this.$element;
+		var o  = this.options;
+
+		return $e.attr('data-message-placeholder') || (typeof o.target == 'function' ? o.target.call($e[0]) : o.messagePlaceholder);
 	}
 
 	Confirmation.prototype.isPopout = function () {

--- a/bootstrap-confirmation.js
+++ b/bootstrap-confirmation.js
@@ -121,9 +121,6 @@
 
 
 		if(this.getMessageName()) {
-
-
-
 			$tip.css('min-width', '300px');
 			$content.addClass('container-fluid');
 			var form = $('<form>').attr('action', this.getHref()).attr('target', this.getTarget());
@@ -139,12 +136,13 @@
 				.attr('placeholder', this.getMessagePlaceholder())
 				.addClass('form-control input-sm');
 
-			form.append($('<div>', {'class' :'form-group'}).append(input));
+			form.append($('<div>', {'class' :'row'}).append($('<div>', {'class' :'col-sm-12'}).append(input)));
 			form.append(
-				$('<div>', {'class' :'form-group'})
-					.append($btnOk)
-					.append('&nbsp;')
-					.append($btnCancel)
+				$('<div>', {'class' :'row'})
+					.append($('<div>', {'class' :'col-sm-12'})
+						.append($btnOk)
+						.append('&nbsp;')
+						.append($btnCancel))
 			);
 
 			$content.html(form);


### PR DESCRIPTION
… is send along a GET request to the target href. This can for example be used to pass the reason the a destructive operation or to pass an auth code to the backend

Still todo:
 - Handle POST actions
 - Set field as required