### PR TITLE
Fixes discarding form-data on submit-button. (Fix for #47)

### DIFF
--- a/bootstrap-confirmation.js
+++ b/bootstrap-confirmation.js
@@ -135,17 +135,17 @@
 
 				// If the button is a submit one
 				if (that.$element.attr('type') == 'submit') {
-                    var $hiddenInput = null;
+					var $hiddenInput = null;
 					var form = that.$element.closest('form').first();
 					var name = that.$element.attr('name');
 
 					// If the submit-button has form-data to transmit
-					if (name.length > 0) {
+					if (typeof name != "undefined" && name.length > 0) {
 						var value = that.$element.attr('value');
 
-                        // Add the data from the submit-button to the form as hidden input.
-                        // These data would be lost by using form.submit(), bypassing the button.
-                        $hiddenInput = $("<input type='hidden' name='" + name + "' value='" + value + "' />");
+						// Add the data from the submit-button to the form as hidden input.
+						// These data would be lost by using form.submit(), bypassing the button.
+						$hiddenInput = $("<input type='hidden' name='" + name + "' value='" + value + "' />");
 
 						that.$element.prepend($hiddenInput);
 					}

--- a/bootstrap-confirmation.js
+++ b/bootstrap-confirmation.js
@@ -134,8 +134,28 @@
 				options.onConfirm(event, that.$element);
 
 				// If the button is a submit one
-				if (that.$element.attr('type') == 'submit')
-					that.$element.closest('form').first().submit();
+				if (that.$element.attr('type') == 'submit') {
+                    var $hiddenInput = null;
+					var form = that.$element.closest('form').first();
+					var name = that.$element.attr('name');
+
+					// If the submit-button has form-data to transmit
+					if (name.length > 0) {
+						var value = that.$element.attr('value');
+
+                        // Add the data from the submit-button to the form as hidden input.
+                        // These data would be lost by using form.submit(), bypassing the button.
+                        $hiddenInput = $("<input type='hidden' name='" + name + "' value='" + value + "' />");
+
+						that.$element.prepend($hiddenInput);
+					}
+
+					form.submit();
+
+                    if ($hiddenInput != null) {
+                        $hiddenInput.remove();
+                    }
+				}
 
 				that.hide();
 				that.inState.click = false;

--- a/bootstrap-confirmation.js
+++ b/bootstrap-confirmation.js
@@ -152,9 +152,9 @@
 
 					form.submit();
 
-                    if ($hiddenInput != null) {
-                        $hiddenInput.remove();
-                    }
+					if ($hiddenInput != null) {
+						$hiddenInput.remove();
+					}
 				}
 
 				that.hide();


### PR DESCRIPTION
This should fix #47 (Form-data on submit-button is discarded). It detects form-data on the submit-button and add's a temporary hidden input before the submit-button containing the form-data from the button before calling form.submit().
