### PR TITLE
Handle multiple submit buttons

### DIFF
--- a/bootstrap-confirmation.js
+++ b/bootstrap-confirmation.js
@@ -124,7 +124,20 @@
                     var novalidate = form.attr('novalidate') !== undefined;
 
                     if (novalidate || form[0].checkValidity()) {
-                        form.submit();
+                        var submits = form.find('input[type=submit]');
+                        if (submits.length === 1) {
+                            form.submit();
+                        } else {
+                            //more than one submit button, set hide popover and complete click
+                            that.inState.click = false;
+                            that.hide();
+                            //destroy confirmation (we're going to submit)
+                            that.$element.confirmation('destroy');
+                            window.setTimeout(function () {
+                                //destroy confirmation then trigger click on the specific button
+                                that.$element.trigger('click');
+                            }.bind(that), 250);
+                        }
                     }
                 }
 


### PR DESCRIPTION
When using bs-confirmation with multiple input[type=submit] buttons, the current behaviour is to trigger form.submit after confirmation is received. If you have multiple submit buttons (with unique names/values) then this submits the form with the wrong action. This commit changes that behaviour so that if there are multiple submit buttons, the confirmation is destroyed then the click event reinvoked causing the original submit action to occur (which is browser submitting the form with the correct name/value specified for the clicked button)